### PR TITLE
Add column name aliasing, case insensitive property names, DBNull for null parameters

### DIFF
--- a/src/WebMatrix.Data.StronglyTyped.Tests/ExecuteTests.cs
+++ b/src/WebMatrix.Data.StronglyTyped.Tests/ExecuteTests.cs
@@ -45,12 +45,21 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 
 		[Test]
 		public void Inserts_record() {
-			using (var db = Database.Open("Test")) {
+			using(var db = Database.Open("Test")) {
 				db.Insert(new User { Name = "Foo" });
 
 				var result = db.Query<User>("select * from users").Single();
 				result.Id.ShouldEqual(1);
 				result.Name.ShouldEqual("Foo");
+			}
+		}
+		[Test]
+		public void Inserts_record_with_aliased_column() {
+			using(var db = Database.Open("Test")) {
+				db.Insert(new UserWithAliasedProperty { OtherName = "FooAliased" });
+
+				var result = db.Query<User>("select * from users").Single();
+				result.Name.ShouldEqual("FooAliased");
 			}
 		}
 
@@ -100,6 +109,13 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 		public class UserWithImplicitId {
 			public int Id { get; set; }
 			public string Name { get; set; }
+		}
+
+		[Table("Users")]
+		public class UserWithAliasedProperty {
+			public int Id { get; set; }
+			[Column("Name")]
+			public string OtherName { get; set; }
 		}
 
 	}

--- a/src/WebMatrix.Data.StronglyTyped.Tests/QueryTests.cs
+++ b/src/WebMatrix.Data.StronglyTyped.Tests/QueryTests.cs
@@ -88,6 +88,17 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 		}
 
 		[Test]
+		public void Gets_property_case_insensitively() {
+			using(var db = Database.Open("Test")) {
+				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
+
+				var results = db.Query<User7>("select * from Users").ToList();
+				results.Count.ShouldEqual(1);
+				results[0].name.ShouldEqual("Jeremy");
+			}
+		}
+
+		[Test]
 		public void Does_not_throw_when_object_does_not_have_property() {
 			using(var db = Database.Open("Test")) {
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
@@ -197,6 +208,12 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			public int Id { get; set; }
 			[Column("Name")]
 			public string OtherName { get; set; }
+		}
+
+		[Table("Users")]
+		public class User7 {
+			public int Id { get; set; }
+			public string name { get; set; }
 		}
 	}
 }

--- a/src/WebMatrix.Data.StronglyTyped.Tests/QueryTests.cs
+++ b/src/WebMatrix.Data.StronglyTyped.Tests/QueryTests.cs
@@ -76,6 +76,16 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			}
 		}
 
+		[Test]
+		public void Gets_property_with_remapped_name() {
+			using(var db = Database.Open("Test")) {
+				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
+
+				var results = db.Query<User6>("select * from Users").ToList();
+				results.Count.ShouldEqual(1);
+				results[0].OtherName.ShouldEqual("Jeremy");
+			}
+		}
 
 		[Test]
 		public void Does_not_throw_when_object_does_not_have_property() {
@@ -180,6 +190,13 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			public int Id { get; set; }
 			[NotMapped]
 			public string Name { get; set; }
+		}
+
+		[Table("Users")]
+		public class User6 {
+			public int Id { get; set; }
+			[Column("Name")]
+			public string OtherName { get; set; }
 		}
 	}
 }

--- a/src/WebMatrix.Data.StronglyTyped/ColumnAttribute.cs
+++ b/src/WebMatrix.Data.StronglyTyped/ColumnAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace WebMatrix.Data.StronglyTyped {
+	using System;
+
+	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+	public class ColumnAttribute : Attribute {
+		public ColumnAttribute(string name) {
+			Name = name;
+		}
+		public string Name { get; private set; }
+	}
+}

--- a/src/WebMatrix.Data.StronglyTyped/Mapper.cs
+++ b/src/WebMatrix.Data.StronglyTyped/Mapper.cs
@@ -26,7 +26,7 @@ namespace WebMatrix.Data.StronglyTyped {
 
 	public class Mapper<T> {
 		readonly Func<T> factory;
-		readonly Dictionary<string, PropertyMetadata<T>> properties = new Dictionary<string, PropertyMetadata<T>>();
+		readonly Dictionary<string, PropertyMetadata<T>> properties;
 		static readonly Lazy<Mapper<T>> instanceCache = new Lazy<Mapper<T>>(() => new Mapper<T>());
 
 		public string TableName { get; private set; }
@@ -36,6 +36,8 @@ namespace WebMatrix.Data.StronglyTyped {
 		}
 
 		private Mapper() {
+			this.properties = new Dictionary<string, PropertyMetadata<T>>(StringComparer.InvariantCultureIgnoreCase);
+
 			factory = CreateActivatorDelegate();
 
 			var attribute = (TableAttribute)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
@@ -113,7 +115,7 @@ namespace WebMatrix.Data.StronglyTyped {
 				}
 				else {
 					columns.Add(property.Property.Name + " = @" + parameterCount++);
-					parameters.Add(property.GetValue(toUpdate));
+					parameters.Add(property.GetValue(toUpdate)??DBNull.Value);
 				}
 			}
 
@@ -128,7 +130,7 @@ namespace WebMatrix.Data.StronglyTyped {
 				string.Join(" AND ",  idColumns)
 			);
 
-			return Tuple.Create(update, parameters.ToArray());
+			return Tuple.Create(update, parameters.ToArray());	
 
 		}
 

--- a/src/WebMatrix.Data.StronglyTyped/Mapper.cs
+++ b/src/WebMatrix.Data.StronglyTyped/Mapper.cs
@@ -51,7 +51,8 @@ namespace WebMatrix.Data.StronglyTyped {
 						select property;
 
 			foreach(var property in properties) {
-				this.properties[property.Name] = new PropertyMetadata<T>(property);
+				var propertyMetadata = new PropertyMetadata<T>(property);
+				this.properties[propertyMetadata.PropertyName] = propertyMetadata;
 			}
 		}
 
@@ -85,7 +86,7 @@ namespace WebMatrix.Data.StronglyTyped {
 			foreach(var property in properties.Values) {
 				if(property.IsId) continue; // assume ID properties are store-generated.
 				
-				columns.Add(property.Property.Name);
+				columns.Add(property.PropertyName);
 				parameterNames.Add("@" + parameterCounter++);
 				parameters.Add(property.GetValue(toInsert));
 			}
@@ -110,11 +111,11 @@ namespace WebMatrix.Data.StronglyTyped {
 
 			foreach(var property in properties.Values) {
 				if(property.IsId) {
-					idColumns.Add(property.Property.Name + " = @" + parameterCount++);
+					idColumns.Add(property.PropertyName + " = @" + parameterCount++);
 					parameters.Add(property.GetValue(toUpdate));
 				}
 				else {
-					columns.Add(property.Property.Name + " = @" + parameterCount++);
+					columns.Add(property.PropertyName + " = @" + parameterCount++);
 					parameters.Add(property.GetValue(toUpdate)??DBNull.Value);
 				}
 			}

--- a/src/WebMatrix.Data.StronglyTyped/PropertyMetadata.cs
+++ b/src/WebMatrix.Data.StronglyTyped/PropertyMetadata.cs
@@ -13,13 +13,26 @@ namespace WebMatrix.Data.StronglyTyped {
 			this.property = property;
 			this.setter = BuildSetterDelegate(property);
 			this.getter = BuildGetterDelegate(property);
-			IsId = Attribute.IsDefined(property, typeof(KeyAttribute)) || property.Name == "Id" || property.Name == "ID";
+			PropertyName = MapPropertyName(property);
+			IsId = 
+				Attribute.IsDefined(property, typeof(KeyAttribute)) || 
+				property.Name == "Id" || property.Name == "ID";
+		}
+
+		static string MapPropertyName(PropertyInfo property) {
+			var attribute = (ColumnAttribute)Attribute.GetCustomAttribute(property, typeof(ColumnAttribute));
+			if(attribute==null) return property.Name;
+			return attribute.Name;
 		}
 
 		public bool IsId { get; private set; }
 
 		public PropertyInfo Property {
 			get { return property; }
+		}
+
+		public string PropertyName { 
+			get; protected set; 
 		}
 
 		public void SetValue(T instance, object value) {
@@ -38,7 +51,6 @@ namespace WebMatrix.Data.StronglyTyped {
 				instance,
 				prop.GetSetMethod(true),
 				Expression.Convert(argument, prop.PropertyType));
-
 
 			return (Action<T, object>)Expression.Lambda(setterCall, instance, argument).Compile();
 		}

--- a/src/WebMatrix.Data.StronglyTyped/StrongTypingExtensions.cs
+++ b/src/WebMatrix.Data.StronglyTyped/StrongTypingExtensions.cs
@@ -39,7 +39,7 @@ namespace WebMatrix.Data.StronglyTyped {
 		public static T FindById<T>(this Database db, object id) {
 			var mapper = Mapper<T>.Create();
 			var idCol = mapper.GetIdColumn();
-			var query = string.Format("select * from {0} where {1} = @0", mapper.TableName, idCol.Property.Name);
+			var query = string.Format("select * from {0} where {1} = @0", mapper.TableName, idCol.PropertyName);
 			return db.Query<T>(query, id).SingleOrDefault();
 		}
 

--- a/src/WebMatrix.Data.StronglyTyped/WebMatrix.Data.StronglyTyped.csproj
+++ b/src/WebMatrix.Data.StronglyTyped/WebMatrix.Data.StronglyTyped.csproj
@@ -42,6 +42,7 @@
     <Reference Include="WebMatrix.Data, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ColumnAttribute.cs" />
     <Compile Include="Mapper.cs" />
     <Compile Include="MappingException.cs" />
     <Compile Include="NotMappedAttribute.cs" />


### PR DESCRIPTION
Hi, I'm not sure if you actively maintain this project, if you do please consider pulling these changes:
- Add support for aliasing column names with attributes (particularly for database columns with names incompatible with property naming rules)
- Ignore case when mapping database columns to properties (could be configurable, but it is mostly harmless as it stands)
- Set update command parameter to DBNull for null parameters to queries
