### PR TITLE
Added delete and select helpers with tests.

### DIFF
--- a/WebMatrix.Data.StronglyTyped.sln
+++ b/WebMatrix.Data.StronglyTyped.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebMatrix.Data.StronglyTyped", "src\WebMatrix.Data.StronglyTyped\WebMatrix.Data.StronglyTyped.csproj", "{7D3BBCDB-C8D9-4522-95DD-B8938D89CB39}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebMatrix.Data.StronglyTyped.Tests", "src\WebMatrix.Data.StronglyTyped.Tests\WebMatrix.Data.StronglyTyped.Tests.csproj", "{03147992-2B9F-4F9B-9A12-656188DC57B0}"

--- a/src/WebMatrix.Data.StronglyTyped.Tests/ExecuteTests.cs
+++ b/src/WebMatrix.Data.StronglyTyped.Tests/ExecuteTests.cs
@@ -33,7 +33,6 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			}
 
 			StrongTypingExtensions.Log = Console.Out;
-
 		}
 
 		[SetUp]
@@ -44,21 +43,119 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 		}
 
 		[Test]
+		public void Deletes_all_records()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				var user = new User { Name = "Foo" };
+				db.Insert(user);
+				user.Name = "Bar";
+				db.Insert(user);
+
+				var users = db.Query<User>();
+				users.Count().ShouldEqual(2);
+
+				db.Delete<User>();
+
+				users = db.Query<User>();
+				users.Count().ShouldEqual(0);
+			}
+		}
+
+		[Test]
+		public void Deletes_records_by_id()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				var user = new User { Name = "Foo" };
+				db.Insert(user);
+				user.Name = "Bar";
+				db.Insert(user);
+				user.Name = "Taco";
+				db.Insert(user);
+
+				var users = db.Query<User>();
+				users.Count().ShouldEqual(3);
+
+				db.Delete<User>("where id = @0", users.First().Id);
+
+				users = db.Query<User>();
+				users.Count().ShouldEqual(2);
+
+				db.Delete<User>("where id = @0", users.Last().Id);
+
+				users = db.Query<User>();
+				users.Count().ShouldEqual(1);
+
+				users.First().Name.ShouldEqual("Bar");
+			}
+		}
+
+		[Test]
+		public void Deletes_records_by_query()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				var user = new User { Name = "Boo" };
+				db.Insert(user);
+				user.Name = "Bar";
+				db.Insert(user);
+				user.Name = "Taco";
+				db.Insert(user);
+				user.Name = "Bacon";
+				db.Insert(user);
+
+				var users = db.Query<User>();
+				users.Count().ShouldEqual(4);
+
+				db.Delete<User>("where name like @0", "b%");
+
+				users = db.Query<User>();
+				users.Count().ShouldEqual(1);
+				users.First().Name.ShouldEqual("Taco");
+			}
+		}
+
+		[Test]
+		public void Deletes_records_only_in_query()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				var user = new User { Name = "Boo" };
+				db.Insert(user);
+				user.Name = "Bar";
+				db.Insert(user);
+				user.Name = "Taco";
+				db.Insert(user);
+				user.Name = "Bacon";
+				db.Insert(user);
+
+				var users = db.Query<User>();
+				users.Count().ShouldEqual(4);
+
+				db.Delete<User>("where name = @0", "monkey");
+
+				users = db.Query<User>();
+				users.Count().ShouldEqual(4);
+			}
+		}
+
+		[Test]
 		public void Inserts_record() {
 			using(var db = Database.Open("Test")) {
 				db.Insert(new User { Name = "Foo" });
 
-				var result = db.Query<User>("select * from users").Single();
-				result.Id.ShouldEqual(1);
+				var result = db.Query<User>().Single();
 				result.Name.ShouldEqual("Foo");
 			}
 		}
+
 		[Test]
 		public void Inserts_record_with_aliased_column() {
 			using(var db = Database.Open("Test")) {
 				db.Insert(new UserWithAliasedProperty { OtherName = "FooAliased" });
 
-				var result = db.Query<User>("select * from users").Single();
+				var result = db.Query<User>().Single();
 				result.Name.ShouldEqual("FooAliased");
 			}
 		}
@@ -71,11 +168,10 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 				user.Name = "Bar";
 				db.Update(user);
 
-				var result = db.Query<User>("select * from users").Single();
+				var result = db.Query<User>().Single();
 				result.Name.ShouldEqual("Bar");
 			}
 		}
-
 
 		[Test]
 		public void Inserts_with_store_generated_id() {
@@ -97,7 +193,6 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			}
 		}
 
-
 		[Table("Users")]
 		public class User {
 			[Key]
@@ -117,7 +212,5 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			[Column("Name")]
 			public string OtherName { get; set; }
 		}
-
 	}
-
 }

--- a/src/WebMatrix.Data.StronglyTyped.Tests/QueryTests.cs
+++ b/src/WebMatrix.Data.StronglyTyped.Tests/QueryTests.cs
@@ -60,12 +60,33 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 		}
 
 		[Test]
-		public void Gets_data_strongly_typed() {
-			using (var db = Database.Open("Test")) {
+		public void Gets_data_strongly_typed()
+		{
+			using (var db = Database.Open("Test"))
+			{
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 				db.Execute("insert into Users (Id, Name) values (2, 'Bob')");
 
-				var results = db.Query<User>("select * from Users").ToList();
+				var results = db.Query<User>().ToList();
+				results.Count.ShouldEqual(2);
+
+				results[0].Id.ShouldEqual(1);
+				results[0].Name.ShouldEqual("Jeremy");
+
+				results[1].Id.ShouldEqual(2);
+				results[1].Name.ShouldEqual("Bob");
+			}
+		}
+
+		[Test]
+		public void Gets_data_strongly_typed_raw()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
+				db.Execute("insert into Users (Id, Name) values (2, 'Bob')");
+
+				var results = db.QuerySql<User>("select * from Users").ToList();
 				results.Count.ShouldEqual(2);
 
 				results[0].Id.ShouldEqual(1);
@@ -81,7 +102,20 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			using(var db = Database.Open("Test")) {
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 
-				var results = db.Query<User6>("select * from Users").ToList();
+				var results = db.Query<User6>().ToList();
+				results.Count.ShouldEqual(1);
+				results[0].OtherName.ShouldEqual("Jeremy");
+			}
+		}
+
+		[Test]
+		public void Gets_property_with_remapped_name_raw()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
+
+				var results = db.QuerySql<User6>("select * from Users").ToList();
 				results.Count.ShouldEqual(1);
 				results[0].OtherName.ShouldEqual("Jeremy");
 			}
@@ -92,18 +126,33 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			using(var db = Database.Open("Test")) {
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 
-				var results = db.Query<User7>("select * from Users").ToList();
+				var results = db.Query<User7>().ToList();
 				results.Count.ShouldEqual(1);
 				results[0].name.ShouldEqual("Jeremy");
 			}
 		}
 
 		[Test]
-		public void Does_not_throw_when_object_does_not_have_property() {
-			using(var db = Database.Open("Test")) {
+		public void Gets_property_case_insensitively_raw()
+		{
+			using (var db = Database.Open("Test"))
+			{
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 
-				var results = db.Query<User>("select Name as Foo from Users").ToList();
+				var results = db.QuerySql<User7>("select * from Users").ToList();
+				results.Count.ShouldEqual(1);
+				results[0].name.ShouldEqual("Jeremy");
+			}
+		}
+
+		[Test]
+		public void Does_not_throw_when_object_does_not_have_property()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
+
+				var results = db.QuerySql<User>("select Name as Foo from Users").ToList();
 				results.Single().Name.ShouldBeNull();
 			}
 		}
@@ -113,7 +162,7 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			using(var db = Database.Open("Test")) {
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 
-				db.Query<User2>("select Name from Users").ToList();
+				db.QuerySql<User2>("select Name from Users").ToList();
 			}
 		}
 
@@ -122,7 +171,7 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			using (var db = Database.Open("Test")) {
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 
-				var ex = Assert.Throws<MappingException>(() => db.Query<User3>("select Name from Users").ToList());
+				var ex = Assert.Throws<MappingException>(() => db.QuerySql<User3>("select Name from Users").ToList());
 				ex.Message.ShouldEqual("Could not map the property 'Name' as its data type does not match the database.");
 			}
 		}
@@ -132,26 +181,43 @@ namespace WebMatrix.Data.StronglyTyped.Tests {
 			using(var db = Database.Open("Test")) {
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 
-				var ex = Assert.Throws<MappingException>(() => db.Query<User4>("select * from Users").ToList());
+				var ex = Assert.Throws<MappingException>(() => db.Query<User4>().ToList());
 				ex.Message.ShouldEqual("Could not find a parameterless constructor on the type 'WebMatrix.Data.StronglyTyped.Tests.QueryTests+User4'. WebMatrix.Data.StronglyTyped can only be used to map types that have a public, parameterless constructor.");
 
 			}
 		}
 
 		[Test]
-		public void Does_not_map_properties_with_NotMapped_attribute() {
-			using (var db = Database.Open("Test")) {
+		public void Does_not_map_properties_with_NotMapped_attribute()
+		{
+			using (var db = Database.Open("Test"))
+			{
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 
-				var result = db.Query<User5>("select * from Users").Single();
+				var result = db.Query<User5>().Single();
 				result.Id.ShouldEqual(1);
 				result.Name.ShouldBeNull();
 			}
 		}
 
 		[Test]
-		public void FindAll_gets_all() {
-			using(var db = Database.Open("Test")) {
+		public void Does_not_map_properties_with_NotMapped_attribute_raw()
+		{
+			using (var db = Database.Open("Test"))
+			{
+				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
+
+				var result = db.QuerySql<User5>("select * from Users").Single();
+				result.Id.ShouldEqual(1);
+				result.Name.ShouldBeNull();
+			}
+		}
+
+		[Test]
+		public void FindAll_gets_all()
+		{
+			using (var db = Database.Open("Test"))
+			{
 				db.Execute("insert into Users (Id, Name) values (1, 'Jeremy')");
 				db.Execute("insert into Users (Id, Name) values (2, 'Jeremy')");
 


### PR DESCRIPTION
Minimal helpers for delete (primarily so you dont have to specify the table name) and select (moves away from select *), with some string caching for the generated sql calls.

I didnt see your SimpleQuery project until after this was done, but the same sugar could work well in that project, also.

But, I did break your api a bit (Query became QuerySql because of how Im passing in where clauses), so please dont hesitate to reject this pull request.  I just wanted you to be aware of possible enhancements.

Thanks for all your work,

Jesse
